### PR TITLE
Change waf-light shebang to say explicitly python3 

### DIFF
--- a/waf-light
+++ b/waf-light
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # encoding: latin-1
 # Thomas Nagy, 2005-2018
 #


### PR DESCRIPTION
Change waf-light shebang to say explicitly python3 . See https://github.com/ArduPilot/ardupilot/issues/25923