### PR TITLE
Cope with Python 3.12

### DIFF
--- a/build_system_kit/noscript/dbdlib.py
+++ b/build_system_kit/noscript/dbdlib.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
-import os, sys, imp
+import os, sys
+import types
 from waflib import Context, Options, Configure, Utils, Logs, TaskGen, Task
 import waflib.Tools.c
 
@@ -48,7 +49,7 @@ def start(cwd, version, wafdir):
 	Logs.init_log()
 	Context.waf_dir = wafdir
 	Context.out_dir = Context.top_dir = Context.run_dir = cwd
-	Context.g_module = imp.new_module('wscript')
+	Context.g_module = types.ModuleType('wscript')
 	Context.g_module.root_path = cwd
 	Context.Context.recurse = recurse_rep
 

--- a/build_system_kit/nostate/ebdlib.py
+++ b/build_system_kit/nostate/ebdlib.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-import os, sys, imp, time
+import os, sys, time
 from waflib import Context, Options, Configure, Utils, Logs, TaskGen, Task, Build, ConfigSet
 import waflib.Tools.c
 

--- a/build_system_kit/overview/bbdlib.py
+++ b/build_system_kit/overview/bbdlib.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
-import os, sys, imp
+import os, sys
+import types
 from waflib import Context, Options, Configure, Utils, Logs
 
 def start(cwd, version, wafdir):
@@ -15,7 +16,7 @@ def start(cwd, version, wafdir):
 	Context.waf_dir = wafdir
 	Context.top_dir = Context.run_dir = cwd
 	Context.out_dir = os.path.join(cwd, 'build')
-	Context.g_module = imp.new_module('wscript')
+	Context.g_module = types.ModuleType('wscript')
 	Context.g_module.root_path = os.path.join(cwd, 'bbit')
 	Context.Context.recurse = \
 		lambda x, y: getattr(Context.g_module, x.cmd or x.fun, Utils.nada)(x)

--- a/build_system_kit/parser/cbdlib.py
+++ b/build_system_kit/parser/cbdlib.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
-import os, sys, imp, re
+import os, sys, re
+import types
 from waflib import Context, Options, Configure, Utils, Logs
 
 def options(opt):
@@ -48,7 +49,7 @@ def start(cwd, version, wafdir):
 	Context.waf_dir = wafdir
 	Context.top_dir = Context.run_dir = cwd
 	Context.out_dir = os.path.join(cwd, 'build')
-	Context.g_module = imp.new_module('wscript')
+	Context.g_module = types.ModuleType('wscript')
 	Context.g_module.root_path = os.path.join(cwd, 'cbit')
 	Context.Context.recurse = recurse_rep
 

--- a/waflib/Context.py
+++ b/waflib/Context.py
@@ -6,7 +6,8 @@
 Classes and functions enabling the command system
 """
 
-import os, re, imp, sys
+import os, re, sys
+import types
 from waflib import Utils, Errors, Logs
 import waflib.Node
 
@@ -607,13 +608,13 @@ class Context(ctx):
 		Logs.pprint(color, msg)
 
 	def load_special_tools(self, var, ban=[]):
-		"""
+		r"""
 		Loads third-party extensions modules for certain programming languages
 		by trying to list certain files in the extras/ directory. This method
 		is typically called once for a programming language group, see for
 		example :py:mod:`waflib.Tools.compiler_c`
 
-		:param var: glob expression, for example 'cxx\_\*.py'
+		:param var: glob expression, for example 'cxx_*.py'
 		:type var: string
 		:param ban: list of exact file names to exclude
 		:type ban: list of string
@@ -660,7 +661,8 @@ def load_module(path, encoding=None):
 	except KeyError:
 		pass
 
-	module = imp.new_module(WSCRIPT_FILE)
+	module = types.ModuleType(WSCRIPT_FILE)
+
 	try:
 		code = Utils.readf(path, m='r', encoding=encoding)
 	except EnvironmentError:


### PR DESCRIPTION
Replace use of deprecated packages that are removed in Python 3.12.

https://stackoverflow.com/questions/32175693/python-importlibs-analogue-for-imp-new-module
- replace `imp.new_module` with `types. ModuleType`.

https://peps.python.org/pep-0632/
- replace `distutils.sysconfig` with `sysconfig`.
- replace `distutils.sysconfig.get_config_var` with `sysconfig.get_config_var`.

https://bugs.python.org/issue41282
- replace `distutils.sysconfig.get_python_lib` with `sysconfig.get_path`.

https://github.com/Azure/azure-cli/pull/17667/files
- replace `distutils.version.LooseVersion` with `packaging.version.parse`.

### Tasks

- [ ] find replacement for `distutils.msvccompiler.MSVCCompiler`.
- [ ] confirm replacement of `distutils.sysconfig.get_python_lib` is correct.
- [ ] confirm backwards compatibility to Python 3.4 (or 3.6?).
- [ ] fix dronecan module not being imported correctly during build

### Related

- https://github.com/dronecan/pydronecan/pull/56
